### PR TITLE
Add ALB DNS Integration for Web Application

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "web" {
   instance_type          = "t2.micro"
   key_name               = var.key_name
   subnet_id              = aws_subnet.public[count.index].id
-  vpc_security_group_ids = [aws_security_group.ec2_sg.id]
+  vpc_security_group_ids = [aws_security_group.web_app_sg.id]
 
   user_data = <<-EOF
     #!/bin/bash
@@ -24,8 +24,64 @@ resource "aws_instance" "web" {
     sudo yum install -y httpd
     sudo systemctl start httpd
     sudo systemctl enable httpd
-    echo "<h1>Hello from EC2-${count.index + 1} in subnet $(hostname -I)</h1>" | sudo tee /var/www/html/index.html
+    
+    # Store ALB DNS name in environment variable
+    echo "WEB_SERVER_ALB_DNS=${aws_lb.web_server_alb.dns_name}" | sudo tee -a /etc/environment
+    
+    # Create a sample page that uses the ALB DNS
+    cat <<HTML | sudo tee /var/www/html/index.html
+    <h1>Web Application ${count.index + 1}</h1>
+    <p>This app connects to web server at: ${aws_lb.web_server_alb.dns_name}</p>
+    <div id="result">Loading...</div>
+    <script>
+      fetch('http://${aws_lb.web_server_alb.dns_name}')
+        .then(response => response.text())
+        .then(data => document.getElementById('result').innerHTML = data)
+        .catch(error => document.getElementById('result').innerHTML = "Error: " + error);
+    </script>
+    HTML
   EOF
 
-  tags = { Name = "Terraform-EC2-${count.index + 1}" }
+  depends_on = [aws_lb.web_server_alb]
+
+  tags = { Name = "Web-Application-EC2-${count.index + 1}" }
 }
+
+# Launch EC2 Instances in Private Subnets
+resource "aws_instance" "web_server" {
+  count                  = var.number_of_azs
+  ami                    = data.aws_ami.latest_amazon_linux.id
+  instance_type          = "t2.micro"
+  key_name               = var.key_name
+  subnet_id              = aws_subnet.public[count.index].id
+  vpc_security_group_ids = [aws_security_group.web_server_sg.id]
+
+  user_data = <<-EOF
+    #!/bin/bash
+    sudo yum update -y
+    sudo yum install -y httpd
+    sudo systemctl start httpd
+    sudo systemctl enable httpd
+    echo "<h1>Hello from Web Server EC2-${count.index + 1} in subnet $(hostname -I)</h1>" | sudo tee /var/www/html/index.html
+    sudo sed -i 's/Listen 80/Listen 8080/g' /etc/httpd/conf/httpd.conf
+    sudo systemctl restart httpd
+  EOF
+
+  tags = { Name = "WebServer-EC2-${count.index + 1}" }
+}
+
+
+
+# Launch Bastion Host in Public Subnet
+resource "aws_instance" "bastion" {
+  ami                         = data.aws_ami.latest_amazon_linux.id
+  instance_type               = "t2.micro"
+  key_name                    = var.key_name
+  subnet_id                   = aws_subnet.public[0].id # Bastion should be in a public subnet
+  vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
+  associate_public_ip_address = true # Required for SSH access
+
+  tags = { Name = "Bastion-Host" }
+}
+
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,8 +2,20 @@ output "alb_dns_name" {
   value = aws_lb.app_alb.dns_name
 }
 
-output "ec2_public_ips" {
-  description = "Public IPs of EC2 instances"
-  value       = aws_instance.web[*].public_ip
+output "bastion_public_ip" {
+  description = "Public IP of the Bastion Host"
+  value       = aws_instance.bastion.public_ip
 }
+
+output "web_server_private_ips" {
+  description = "Private IPs of Web Server instances"
+  value       = [for instance in aws_instance.web_server : instance.private_ip]
+}
+
+# Output the ALB DNS Name for Web Server
+output "web_server_alb_dns" {
+  description = "DNS name of the Web Server ALB"
+  value       = aws_lb.web_server_alb.dns_name
+}
+
 

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,21 +1,14 @@
-# Security Group for EC2 Instances
-resource "aws_security_group" "ec2_sg" {
-  name        = "ec2_security_group"
-  description = "Allow SSH and HTTP access"
+# Security Group for Web Application EC2 Instances
+resource "aws_security_group" "web_app_sg" {
+  name        = "web-app-sg"
+  description = "Allow HTTP access"
   vpc_id      = aws_vpc.main.id
-
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   ingress {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["0.0.0.0/0"] # Open for public access
   }
 
   egress {
@@ -25,27 +18,28 @@ resource "aws_security_group" "ec2_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = { Name = "ec2-security-group" }
+  tags = { Name = "web-app-sg" }
 }
+
 
 # Security Group for ALB
 resource "aws_security_group" "alb_sg" {
-  name        = "alb_security_group"
+  name        = "alb-security-group"
   description = "Allow HTTP and HTTPS traffic"
-  vpc_id      = aws_vpc.main.id 
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["0.0.0.0/0"] # Open to internet
   }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["0.0.0.0/0"] # Open to internet
   }
 
   egress {
@@ -58,3 +52,139 @@ resource "aws_security_group" "alb_sg" {
   tags = { Name = "alb-security-group" }
 }
 
+# Security Group for Bastion Host
+resource "aws_security_group" "bastion_sg" {
+  name        = "bastion-sg"
+  description = "Allow SSH from a specific IP range"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # Replace with your actual IP
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "bastion-sg" }
+}
+
+# Allow SSH from Bastion to Web Application EC2
+resource "aws_security_group_rule" "allow_ssh_from_bastion" {
+  type                     = "ingress"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.web_app_sg.id
+  source_security_group_id = aws_security_group.bastion_sg.id
+}
+
+
+
+
+
+
+
+
+
+# ---------------------------------------------
+# Security Group for Web Server EC2 Instances
+resource "aws_security_group" "web_server_sg" {
+  name        = "web-server-sg"
+  description = "Allow HTTP access from ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.web_server_alb_sg.id] # Allow traffic only from ALB
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "web-server-sg" }
+}
+
+# Security Group for Web Server ALB
+resource "aws_security_group" "web_server_alb_sg" {
+  name        = "web-server-alb-sg"
+  description = "Allow traffic to web server from the web app"
+  vpc_id      = aws_vpc.main.id
+
+  # Updated to accept traffic from the web application security group
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.web_app_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "web-server-alb-sg" }
+}
+
+
+# Application Load Balancer for Web Server
+resource "aws_lb" "web_server_alb" {
+  name               = "web-server-alb"
+  internal           = true # Changed to internal since it's only accessed by web app
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.web_server_alb_sg.id]
+  subnets            = aws_subnet.private[*].id # Assuming you have private subnets
+
+  tags = { Name = "web-server-alb" }
+}
+
+# ALB Target Group
+resource "aws_lb_target_group" "web_server_tg" {
+  name     = "web-server-tg"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 3
+    unhealthy_threshold = 2
+  }
+  tags = { Name = "web-server-tg" }
+}
+
+# ALB Listener for Web Server
+resource "aws_lb_listener" "web_server_listener" {
+  load_balancer_arn = aws_lb.web_server_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web_server_tg.arn
+  }
+}
+
+# Attach Web Server EC2 Instances to ALB Target Group
+resource "aws_lb_target_group_attachment" "web_server_attachment" {
+  count            = var.number_of_azs
+  target_group_arn = aws_lb_target_group.web_server_tg.arn
+  target_id        = aws_instance.web_server[count.index].id
+  port             = 8080
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,4 +1,8 @@
-aws_region    = "us-east-1"
-key_name      = "test-key-pair"
-number_of_azs = 2
-# dockerhub_image = "phulam11031996/web-app:latest"
+aws_region                 = "us-east-1"
+key_name                   = "test-key-pair"
+number_of_azs              = 2
+dockerhub_image            = "phulam11031996/web-app:latest"
+web_server_dockerhub_image = "phulam11031996/web-server:latest"
+
+alb_name = "test-alb-name" # Replace with your ALB name
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,3 +20,19 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.0.0.0/16"
 }
+
+variable "dockerhub_image" {
+  description = "The name of the SSH key pair"
+  type        = string
+}
+
+variable "web_server_dockerhub_image" {
+  description = "Docker Hub image for the web server"
+  type        = string
+}
+
+
+variable "alb_name" {
+  description = "Name of the Application Load Balancer"
+  type        = string
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -21,6 +21,17 @@ resource "aws_subnet" "public" {
   tags = { Name = "public-subnet-${count.index + 1}" }
 }
 
+# Create Private Subnets
+resource "aws_subnet" "private" {
+  count                   = var.number_of_azs
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 4, count.index + var.number_of_azs) # Avoid overlap with public subnets
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = false # Private subnet should not auto-assign public IPs
+
+  tags = { Name = "private-subnet-${count.index + 1}" }
+}
+
 # Create Internet Gateway
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.main.id


### PR DESCRIPTION
# Description:

- Updated EC2 instances to store and use the ALB DNS name.
- Modified security groups for better traffic control.
- Added a Bastion host for secure SSH access.
- Configured ALB, target groups, and listeners for web server routing.
- Refactored Terraform variables for improved manageability.

# Changes:

- Updated ec2.tf, security_group.tf, variables.tf, and outputs.tf.
- Added web_server_dockerhub_image variable.
- Enabled internal ALB communication for the web app.